### PR TITLE
Fix error with latest haxe 4 builds

### DIFF
--- a/src/pixi/core/renderers/webgl/filters/Filter.hx
+++ b/src/pixi/core/renderers/webgl/filters/Filter.hx
@@ -100,7 +100,7 @@ extern class Filter {
 	function apply(filterManager:FilterManager, input:RenderTarget, output:RenderTarget, ?clear:Bool, ?currentState:CurrentState):Void;
 }
 
-interface CurrentState implements Dynamic
+extern interface CurrentState implements Dynamic
 {
 	var destinationFrame:Rectangle;
 	var filters:Array<Filter>;


### PR DESCRIPTION
The latest haxe 4 builds will error with 
> In haxe 4, implements Dynamic is only supported on externs

So CurrentState has been marked as extern to prevent this error

Should not have any impact on existing code