### PR TITLE
Add missing dirty: Int flag to Graphics

### DIFF
--- a/src/pixi/core/graphics/Graphics.hx
+++ b/src/pixi/core/graphics/Graphics.hx
@@ -94,6 +94,14 @@ extern class Graphics extends Container {
 	var boundsPadding:Float;
 
 	/**
+	 * Used to detect if the graphics object has changed. If this is set to true then the graphics
+	 * object will be recalculated.
+	 *
+	 * @member {boolean}
+	 */
+	var dirty: Int;
+
+	/**
 	 * Used to detect if we need to do a fast rect check using the id compare method
 	 * @type {Int}
 	 */


### PR DESCRIPTION
The `dirty` flag is used to inform the renderer that the `graphicsData` has changed

Details here: http://www.html5gamedevs.com/topic/9374-change-the-style-of-line-that-is-already-drawn/?tab=comments#comment-55611